### PR TITLE
Add dockerfile define python2.7 compatible environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
+.PHONY: docker docker-build docker-run
 
 .venv venv:
 	virtualenv -ppython2 .venv
 	.venv/bin/pip install imread numpy==1.16
+
+docker: docker-build docker-run
+
+docker-build:
+	docker image build -t online-go-flags .
+
+docker-run:
+	@docker run -it --rm --mount type=bind,src=.,dst=/work online-go-flags:latest /bin/ash

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7-alpine
+
+RUN apk update
+RUN apk add build-base tiff-dev libjpeg-turbo-dev libpng-dev imagemagick
+RUN pip install imread
+RUN pip install numpy==1.16
+
+RUN install -d /work
+
+WORKDIR /work


### PR DESCRIPTION
Offering this up as an alternative to virtualenv. The docker container is a bit more isolated from the host, which I think is useful in this case because building imread and numpy invokes the hosts toolchain.

Running `make docker` will build the docker image and open an ephemeral container that is mounted to the top dir of the repo for ease of use.